### PR TITLE
Fix failing GitHub Actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,6 +36,12 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
       - name: Install libbi (linux)
         if: runner.os == 'linux'
         run: |
@@ -53,12 +59,6 @@ jobs:
       - name: Install libbi (mac)
         if: runner.os == 'macOS'
         run: brew install libbi
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/_pkgdown.yml
+++ b/.github/workflows/_pkgdown.yml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
       - name: Install libbi
         run: |
           sudo apt-get install build-essential libblas-dev liblapack-dev \
@@ -34,12 +40,6 @@ jobs:
           sudo cpanm --installdeps --notest .
           sudo cpanm --force .
           cd ..
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
       - name: Install libbi
         run: |
           sudo apt-get install build-essential libblas-dev liblapack-dev \
@@ -33,10 +37,6 @@ jobs:
           sudo cpanm --installdeps --notest .
           sudo cpanm --force .
           cd ..
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Some of the GHA failures in #46 are not due to my changes but to an issue with the workflows currently on `main`. In short, `apt-get update` needs to run before `apt-get install`. Reordering the steps fixes this because `setup-r` already runs `apt-get update`.